### PR TITLE
Chore/replace subject with observable

### DIFF
--- a/packages/current-account-stream/index.js
+++ b/packages/current-account-stream/index.js
@@ -1,11 +1,12 @@
-const { Subject, from, merge } = require("rxjs");
+const { Observable, from, merge } = require("rxjs");
 const { map, distinctUntilChanged, switchMap } = require("rxjs/operators");
 
 // wraps an un-documented API for updates into a stream
 const createUpdate$ = web3 => {
-  const observable = new Subject();
-  web3.currentProvider.publicConfigStore.on("update", data => {
-    observable.next(data);
+  const observable = new Observable(subscriber => {
+    web3.currentProvider.publicConfigStore.on("update", data => {
+      subscriber.next(data);
+    });
   });
   return observable;
 };

--- a/packages/new-block-stream/fromPolling.js
+++ b/packages/new-block-stream/fromPolling.js
@@ -1,4 +1,4 @@
-const { Subject } = require("rxjs");
+const { Observable } = require("rxjs");
 const PollingBlockTracker = require("eth-block-tracker");
 
 const fromPolling = ({ web3, pollingInterval }) => {
@@ -9,14 +9,15 @@ const fromPolling = ({ web3, pollingInterval }) => {
   const provider = web3.currentProvider;
   const blockTracker = new PollingBlockTracker({ provider, pollingInterval });
 
-  const observable = new Subject();
-  blockTracker
-    .on("latest", async blockNum => {
-      // get full block info with `web3.eth.getBlock`
-      const block = await web3.eth.getBlock(blockNum, true);
-      observable.next(block);
-    })
-    .on("error", err => observable.next(err));
+  const observable = new Observable(subscriber => {
+    blockTracker
+      .on("latest", async blockNum => {
+        // get full block info with `web3.eth.getBlock`
+        const block = await web3.eth.getBlock(blockNum, true);
+        subscriber.next(block);
+      })
+      .on("error", err => subscriber.next(err));
+  });
 
   return {
     observable,


### PR DESCRIPTION
Resolves #46 

I've left out the subscription method for new-block-stream because it complicates things since we need the subscription object to be returned immediately. Therefore, the creation of that stream still uses a Subject.

All tests pass locally.