### PR TITLE
Update to include a request to enable the browser

### DIFF
--- a/packages/get-web3/README.md
+++ b/packages/get-web3/README.md
@@ -57,3 +57,11 @@ const web3 = await getWeb3({ fallbackProvider });
 ```
 
 For detailed usage example, see the `test-app` directory, specifically `test-app/src/App.js`.
+
+### Request Permissions
+
+There is also a handy `requestPermission` option that will call `window.ethereum.enable()` for you.
+
+```js
+const web3 = await getWeb3({ requestPermission: true });
+```

--- a/packages/get-web3/index.js
+++ b/packages/get-web3/index.js
@@ -9,7 +9,7 @@ const resolveWeb3 = (resolve, options, isBrowser) => {
   } else if (isBrowser && window.ethereum) {
     // use `ethereum` object injected by MetaMask
     provider = window.ethereum;
-    if(!options.requestPermission) window.ethereum.enable();
+    if(options.requestPermission) window.ethereum.enable();
   } else if (isBrowser && typeof window.web3 !== "undefined") {
     // use injected web3 object by legacy dapp browsers
     provider = window.web3.currentProvider;

--- a/packages/get-web3/index.js
+++ b/packages/get-web3/index.js
@@ -9,6 +9,7 @@ const resolveWeb3 = (resolve, options, isBrowser) => {
   } else if (isBrowser && window.ethereum) {
     // use `ethereum` object injected by MetaMask
     provider = window.ethereum;
+    if(!options.requestPermission) window.ethereum.enable();
   } else if (isBrowser && typeof window.web3 !== "undefined") {
     // use injected web3 object by legacy dapp browsers
     provider = window.web3.currentProvider;


### PR DESCRIPTION
Currently, getWeb3 does not trigger MetaMask to prompt the user to give access to the accounts. 

This change suggests that the trigger for MetaMask should be done by default, but can be disabled via the options object that is passed in. 

This makes it a bit more convenient, without sacrificing flexibility. 

