### PR TITLE
Feat/polling block tracking

### DIFF
--- a/packages/core/__tests__/__snapshots__/node_env.js.snap
+++ b/packages/core/__tests__/__snapshots__/node_env.js.snap
@@ -15,7 +15,32 @@ Observable {
     },
     "source": Observable {
       "_isScalar": false,
-      "_subscribe": [Function],
+      "operator": MergeMapOperator {
+        "concurrent": 1,
+        "project": [Function],
+      },
+      "source": Observable {
+        "_isScalar": false,
+        "operator": MergeMapOperator {
+          "concurrent": 1,
+          "project": [Function],
+        },
+        "source": Observable {
+          "_isScalar": false,
+          "operator": PairwiseOperator {},
+          "source": Observable {
+            "_isScalar": false,
+            "operator": MergeMapOperator {
+              "concurrent": 1,
+              "project": [Function],
+            },
+            "source": Observable {
+              "_isScalar": false,
+              "_subscribe": [Function],
+            },
+          },
+        },
+      },
     },
   },
 }
@@ -36,7 +61,32 @@ Observable {
     },
     "source": Observable {
       "_isScalar": false,
-      "_subscribe": [Function],
+      "operator": MergeMapOperator {
+        "concurrent": 1,
+        "project": [Function],
+      },
+      "source": Observable {
+        "_isScalar": false,
+        "operator": MergeMapOperator {
+          "concurrent": 1,
+          "project": [Function],
+        },
+        "source": Observable {
+          "_isScalar": false,
+          "operator": PairwiseOperator {},
+          "source": Observable {
+            "_isScalar": false,
+            "operator": MergeMapOperator {
+              "concurrent": 1,
+              "project": [Function],
+            },
+            "source": Observable {
+              "_isScalar": false,
+              "_subscribe": [Function],
+            },
+          },
+        },
+      },
     },
   },
 }
@@ -57,7 +107,32 @@ Observable {
     },
     "source": Observable {
       "_isScalar": false,
-      "_subscribe": [Function],
+      "operator": MergeMapOperator {
+        "concurrent": 1,
+        "project": [Function],
+      },
+      "source": Observable {
+        "_isScalar": false,
+        "operator": MergeMapOperator {
+          "concurrent": 1,
+          "project": [Function],
+        },
+        "source": Observable {
+          "_isScalar": false,
+          "operator": PairwiseOperator {},
+          "source": Observable {
+            "_isScalar": false,
+            "operator": MergeMapOperator {
+              "concurrent": 1,
+              "project": [Function],
+            },
+            "source": Observable {
+              "_isScalar": false,
+              "_subscribe": [Function],
+            },
+          },
+        },
+      },
     },
   },
 }

--- a/packages/new-block-stream/fromPolling.js
+++ b/packages/new-block-stream/fromPolling.js
@@ -1,29 +1,54 @@
-const { Observable } = require("rxjs");
-const PollingBlockTracker = require("eth-block-tracker");
+const { timer, from, of } = require("rxjs");
+const { map, concatMap, startWith, pairwise } = require("rxjs/operators");
+
+// helper function to create an array from [x..y]
+const range = (min, max) => {
+  const len = max - min + 1;
+  const arr = new Array(len);
+  for (var i = 0; i < len; i++) {
+    arr[i] = min + i;
+  }
+  return arr;
+};
 
 const fromPolling = ({ web3, pollingInterval }) => {
   // patch missing method
   web3.currentProvider.sendAsync = web3.currentProvider.send;
 
-  // instantiate block tracker
-  const provider = web3.currentProvider;
-  const blockTracker = new PollingBlockTracker({ provider, pollingInterval });
+  // create a stream to poll the blockchain at an interval
+  const timer$ = timer(0, pollingInterval);
 
-  const observable = new Observable(observer => {
-    blockTracker
-      .on("latest", async blockNum => {
-        // get full block info with `web3.eth.getBlock`
-        const block = await web3.eth.getBlock(blockNum, true);
-        observer.next(block);
-      })
-      .on("error", err => observer.next(err));
-  });
+  // a stream of block numbers, which might miss blocks
+  const latestBlockNum$ = timer$.pipe(
+    concatMap(() => from(web3.eth.getBlock("latest"))),
+    map(block => block.number),
+  );
+
+  // a stream of block numbers that do not miss any blocks
+  const nonSkippingBlockNum$ = latestBlockNum$.pipe(
+    startWith(null),
+    pairwise(),
+    concatMap(([last, curr]) => {
+      const isFirstEvent = last === null;
+      const blockSkipped = curr - last > 1;
+
+      if (isFirstEvent || !blockSkipped) {
+        return of(curr);
+      }
+
+      // fill out block numbers for missing blocks
+      const blockNumArray = range(last + 1, curr);
+      return from(blockNumArray);
+    }),
+  );
+
+  const observable = nonSkippingBlockNum$.pipe(
+    concatMap(num => web3.eth.getBlock(num, true)),
+  );
 
   return {
     observable,
-    cleanup: () => {
-      blockTracker.removeAllListeners("latest");
-    },
+    cleanup: () => {},
   };
 };
 

--- a/packages/new-block-stream/fromPolling.js
+++ b/packages/new-block-stream/fromPolling.js
@@ -1,5 +1,11 @@
 const { timer, from, of } = require("rxjs");
-const { map, concatMap, startWith, pairwise } = require("rxjs/operators");
+const {
+  distinctUntilChanged,
+  map,
+  concatMap,
+  startWith,
+  pairwise,
+} = require("rxjs/operators");
 
 // helper function to create an array from [x..y]
 const range = (min, max) => {
@@ -22,6 +28,7 @@ const fromPolling = ({ web3, pollingInterval }) => {
   const latestBlockNum$ = timer$.pipe(
     concatMap(() => from(web3.eth.getBlock("latest"))),
     map(block => block.number),
+    distinctUntilChanged(),
   );
 
   // a stream of block numbers that do not miss any blocks

--- a/packages/new-block-stream/fromPolling.js
+++ b/packages/new-block-stream/fromPolling.js
@@ -18,9 +18,6 @@ const range = (min, max) => {
 };
 
 const fromPolling = ({ web3, pollingInterval }) => {
-  // patch missing method
-  web3.currentProvider.sendAsync = web3.currentProvider.send;
-
   // create a stream to poll the blockchain at an interval
   const timer$ = timer(0, pollingInterval);
 

--- a/packages/new-block-stream/package.json
+++ b/packages/new-block-stream/package.json
@@ -4,7 +4,6 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "eth-block-tracker": "^4.1.0",
     "rxjs": "^6.3.3"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1861,13 +1861,6 @@ babel-plugin-transform-regenerator@^6.22.0:
   dependencies:
     regenerator-transform "^0.10.0"
 
-babel-plugin-transform-runtime@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
-  integrity sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=
-  dependencies:
-    babel-runtime "^6.22.0"
-
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"
@@ -3705,17 +3698,6 @@ eth-block-tracker@^3.0.0:
     json-rpc-engine "^3.6.0"
     pify "^2.3.0"
     tape "^4.6.3"
-
-eth-block-tracker@^4.1.0:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/eth-block-tracker/-/eth-block-tracker-4.4.1.tgz#805931fdff240e950c5ea68198a2fdc61b4482d2"
-  integrity sha512-QSz9bizoV4JRRkdvSfQ/z6VimU90wXaGmFEZyRhbOwotVZSMTtI720UM+dr6byDNj+axtZ0DMX0jpj5Kkzx6WQ==
-  dependencies:
-    babel-plugin-transform-runtime "^6.23.0"
-    eth-query "^2.1.0"
-    json-rpc-random-id "^1.0.1"
-    pify "^3.0.0"
-    safe-event-emitter "^1.0.1"
 
 eth-ens-namehash@2.0.8:
   version "2.0.8"
@@ -6100,7 +6082,7 @@ json-rpc-error@^2.0.0:
   dependencies:
     inherits "^2.0.1"
 
-json-rpc-random-id@^1.0.0, json-rpc-random-id@^1.0.1:
+json-rpc-random-id@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-rpc-random-id/-/json-rpc-random-id-1.0.1.tgz#ba49d96aded1444dbb8da3d203748acbbcdec8c8"
   integrity sha1-uknZat7RRE27jaPSA3SKy7zeyMg=


### PR DESCRIPTION
Fixes #105 and #110 

This PR removes the dependency on MetaMask's Eth-Block-Tracker. Instead, it uses simple RxJS to repeatedly call `web3.eth.getBlock()` when appropriate.

Tested to be working with both Ganache and Infura on:

- Web3.js `1.0.0-beta.37`
- Web3.js `1.0.0-beta.55`