### PR TITLE
Refactor/use observable instead of Subject for fromSubscribe in new-block-stream

### DIFF
--- a/packages/contract-call-stream/__tests__/node_env.js
+++ b/packages/contract-call-stream/__tests__/node_env.js
@@ -33,7 +33,7 @@ describe("contract-call-stream tests in node environment", () => {
   });
 
   test("createContractCall$ throws errors when required options fields not found", () => {
-    const { observable: newBlock$ } = createNewBlock$({
+    const newBlock$ = createNewBlock$({
       web3,
       pollingInterval: 200,
     });
@@ -50,7 +50,7 @@ describe("contract-call-stream tests in node environment", () => {
   });
 
   test("can track changes to a call method return value", async done => {
-    const { observable: newBlock$, cleanup } = createNewBlock$({
+    const newBlock$ = createNewBlock$({
       web3,
       pollingInterval: 1,
     });
@@ -68,7 +68,6 @@ describe("contract-call-stream tests in node environment", () => {
         tap(vals => expect(vals).toEqual(["0", "5"])),
         finalize(() => {
           expect.assertions(1);
-          cleanup();
           done();
         }),
       )

--- a/packages/contract-event-stream/__tests__/node_env.js
+++ b/packages/contract-event-stream/__tests__/node_env.js
@@ -75,7 +75,7 @@ describe("contract-event-stream tests in node environment", () => {
   });
 
   test("fromPolling can track events emitted by send method", async done => {
-    const { observable: newBlock$, cleanup } = createNewBlock$({
+    const newBlock$ = createNewBlock$({
       web3,
       pollingInterval: 200,
     });
@@ -97,7 +97,6 @@ describe("contract-event-stream tests in node environment", () => {
         }),
         finalize(() => {
           expect.assertions(4);
-          cleanup();
           done();
         }),
       )

--- a/packages/contract-state-stream/__tests__/node_env.js
+++ b/packages/contract-state-stream/__tests__/node_env.js
@@ -56,7 +56,7 @@ describe("contract-state-stream tests in node environment", () => {
       new Error("The options object with newBlock$ is required"),
     );
 
-    const { observable: newBlock$, cleanup } = createNewBlock$({
+    const newBlock$ = createNewBlock$({
       web3,
       pollingInterval: 1,
     });
@@ -67,12 +67,10 @@ describe("contract-state-stream tests in node environment", () => {
     expect(() => createContractState$({ newBlock$, artifact })).toThrow(
       new Error("The options object with provider is required"),
     );
-
-    cleanup();
   });
 
   test("can track changes to a send method return value", async done => {
-    const { observable: newBlock$, cleanup } = createNewBlock$({
+    const newBlock$ = createNewBlock$({
       web3,
       pollingInterval: 200,
     });
@@ -94,7 +92,6 @@ describe("contract-state-stream tests in node environment", () => {
         }),
         finalize(() => {
           expect.assertions(2);
-          cleanup();
           done();
         }),
       )

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -7,16 +7,12 @@ const _createContractState$ = require("@drizzle-utils/contract-state-stream");
 const _createNewBlock$ = require("@drizzle-utils/new-block-stream");
 
 const createDrizzleUtils = async ({ web3 }) => {
-  const { observable: newBlock$, cleanup: cleanupNewBlock$ } = _createNewBlock$(
-    {
-      web3,
-      pollingInterval: 200, // only used if non-WebsocketProvider
-    },
-  );
+  const newBlock$ = _createNewBlock$({
+    web3,
+    pollingInterval: 200, // only used if non-WebsocketProvider
+  });
 
   const currentAccount$ = await _createCurrentAccount$({ web3 });
-
-  const cleanup = () => cleanupNewBlock$();
 
   const getAccounts = async (options = {}) =>
     await _getAccounts({ web3, ...options });
@@ -73,7 +69,6 @@ const createDrizzleUtils = async ({ web3 }) => {
     createState$,
     newBlock$,
     currentAccount$,
-    cleanup,
   };
 };
 

--- a/packages/get-balance-stream/__tests__/node_env.js
+++ b/packages/get-balance-stream/__tests__/node_env.js
@@ -27,19 +27,16 @@ describe("get-balance-stream tests in node environment", () => {
   });
 
   test("createBalanceStream$ throws errors when required options fields not found", () => {
-    const { observable: newBlock$ } = createNewBlock$({
+    const newBlock$ = createNewBlock$({
       web3,
       pollingInterval: 200,
     });
 
     expect(() => createBalanceStream$()).toThrow();
 
-    expect(() =>
-      createBalanceStream$({
-        newBlock$,
-        web3,
-      }),
-    ).toThrow(new Error("The options object with address is required"));
+    expect(() => createBalanceStream$({ newBlock$, web3 })).toThrow(
+      new Error("The options object with address is required"),
+    );
 
     expect(() =>
       createBalanceStream$({ newBlock$, address: accounts[0] }),
@@ -51,7 +48,7 @@ describe("get-balance-stream tests in node environment", () => {
   });
 
   test("can track balance of addresses", async done => {
-    const { observable: newBlock$, cleanup } = createNewBlock$({
+    const newBlock$ = createNewBlock$({
       web3,
       pollingInterval: 200,
     });
@@ -81,7 +78,6 @@ describe("get-balance-stream tests in node environment", () => {
         ),
         finalize(() => {
           expect.assertions(1);
-          cleanup();
           done();
         }),
       )

--- a/packages/new-block-stream/README.md
+++ b/packages/new-block-stream/README.md
@@ -20,16 +20,13 @@ const createNewBlock$ = require("@drizzle-utils/new-block-stream");
 
 const web3 = new Web3("ws://127.0.0.1:9545");
 
-const { observable, cleanup } = createNewBlock$({
+const newBlock$ = createNewBlock$({
   web3,
   pollingInterval: 200, // only used if non-WebsocketProvider
 });
 
 // log out new blocks
-observable.subscribe(block => console.log(block));
-
-// stop listening to new blocks and end the stream
-cleanup();
+newBlock$.subscribe(block => console.log(block));
 ```
 
 Note that listening to new blocks might skip blocks if polling is being used and the `pollingInterval` is longer than the rate in which new blocks are being produced.
@@ -49,8 +46,4 @@ Creates an RxJS observable that will monitor the blockchain for new blocks. Supp
 
 #### Returns
 
-`Object`
-
 - `observable`: An RxJS observable.
-- `cleanup`: A function for cleaning up listeners and completing/ending the streams created.
-- `subscription`: This is only returned if the provider passed-in is a WebsocketProvider. This is a reference to the underlying [Web3 subscription object](https://web3js.readthedocs.io/en/1.0/web3-eth-subscribe.html#eth-subscribe).

--- a/packages/new-block-stream/__tests__/node_env.js
+++ b/packages/new-block-stream/__tests__/node_env.js
@@ -42,7 +42,7 @@ describe("new-block-stream tests in node environment", () => {
   });
 
   test("fromPolling can track blocks", async done => {
-    const { observable: newBlock$, cleanup } = createNewBlock$({
+    const { observable: newBlock$ } = createNewBlock$({
       web3,
       pollingInterval: 200,
     });
@@ -58,7 +58,6 @@ describe("new-block-stream tests in node environment", () => {
         }),
         finalize(() => {
           expect.assertions(2);
-          cleanup();
           done();
         }),
       )
@@ -75,7 +74,7 @@ describe("new-block-stream tests in node environment", () => {
     const web3Ws = new Web3(provider);
     web3Ws.currentProvider.constructor = WebsocketProvider;
 
-    const { observable: newBlock$, cleanup } = createNewBlock$({
+    const { observable: newBlock$ } = createNewBlock$({
       web3: web3Ws,
       pollingInterval: 200,
     });
@@ -91,7 +90,6 @@ describe("new-block-stream tests in node environment", () => {
         }),
         finalize(() => {
           expect.assertions(2);
-          cleanup();
           done();
         }),
       )

--- a/packages/new-block-stream/__tests__/node_env.js
+++ b/packages/new-block-stream/__tests__/node_env.js
@@ -42,7 +42,7 @@ describe("new-block-stream tests in node environment", () => {
   });
 
   test("fromPolling can track blocks", async done => {
-    const { observable: newBlock$ } = createNewBlock$({
+    const newBlock$ = createNewBlock$({
       web3,
       pollingInterval: 200,
     });
@@ -74,7 +74,7 @@ describe("new-block-stream tests in node environment", () => {
     const web3Ws = new Web3(provider);
     web3Ws.currentProvider.constructor = WebsocketProvider;
 
-    const { observable: newBlock$ } = createNewBlock$({
+    const newBlock$ = createNewBlock$({
       web3: web3Ws,
       pollingInterval: 200,
     });

--- a/packages/new-block-stream/fromPolling.js
+++ b/packages/new-block-stream/fromPolling.js
@@ -50,10 +50,7 @@ const fromPolling = ({ web3, pollingInterval }) => {
     concatMap(num => web3.eth.getBlock(num, true)),
   );
 
-  return {
-    observable,
-    cleanup: () => {},
-  };
+  return observable;
 };
 
 module.exports = fromPolling;

--- a/packages/new-block-stream/fromSubscribe.js
+++ b/packages/new-block-stream/fromSubscribe.js
@@ -5,14 +5,20 @@ const fromSubscribe = ({ web3 }) => {
     const subscription = web3.eth.subscribe(
       "newBlockHeaders",
       async (err, blockHeader) => {
-        if (err) return subscriber.next(err);
+        try {
+          if (err) return subscriber.next(err);
 
-        // get full block info with `web3.eth.getBlock`
-        const block = await web3.eth.getBlock(blockHeader.number, true);
-        subscriber.next(block);
+          // get full block info with `web3.eth.getBlock`
+          const block = await web3.eth.getBlock(blockHeader.number, true);
+          subscriber.next(block);
+        } catch (error) {
+          // eslint-disable-next-line no-console
+          console.error(error);
+          throw error;
+        }
       },
     );
-    return subscription.unsubscribe;
+    return () => subscription.unsubscribe();
   });
 
   return observable;

--- a/packages/new-block-stream/fromSubscribe.js
+++ b/packages/new-block-stream/fromSubscribe.js
@@ -1,24 +1,22 @@
-const { Subject } = require("rxjs");
+const { Observable } = require("rxjs");
 
 const fromSubscribe = ({ web3 }) => {
-  const observable = new Subject();
-  const subscription = web3.eth.subscribe(
-    "newBlockHeaders",
-    async (err, blockHeader) => {
-      if (err) return observable.next(err);
+  const observable = new Observable(subscriber => {
+    const subscription = web3.eth.subscribe(
+      "newBlockHeaders",
+      async (err, blockHeader) => {
+        if (err) return subscriber.next(err);
 
-      // get full block info with `web3.eth.getBlock`
-      const block = await web3.eth.getBlock(blockHeader.number, true);
-      observable.next(block);
-    },
-  );
+        // get full block info with `web3.eth.getBlock`
+        const block = await web3.eth.getBlock(blockHeader.number, true);
+        subscriber.next(block);
+      },
+    );
+    return subscription.unsubscribe;
+  });
 
   return {
     observable,
-    subscription,
-    cleanup: () => {
-      subscription.unsubscribe();
-    },
   };
 };
 

--- a/packages/new-block-stream/fromSubscribe.js
+++ b/packages/new-block-stream/fromSubscribe.js
@@ -15,9 +15,7 @@ const fromSubscribe = ({ web3 }) => {
     return subscription.unsubscribe;
   });
 
-  return {
-    observable,
-  };
+  return observable;
 };
 
 module.exports = fromSubscribe;


### PR DESCRIPTION
Thanks to @jklepatch for bringing this issue up with me. In #47, we left this out because we want to provide access to the underlying subscription. But since we can just give the user the ability to unsubscribe by returning the unsubscribe function inside the observer, perhaps it's better to use this method so we can simplify the API and remove the need for a cleanup function.