### PR TITLE
Update package.json to include the repository

### DIFF
--- a/packages/contract-call-stream/package.json
+++ b/packages/contract-call-stream/package.json
@@ -6,6 +6,11 @@
   "dependencies": {
     "rxjs": "^6.3.3"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/drizzle-utils.git",
+    "directory": "packages/contract-call-stream"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/contract-event-stream/package.json
+++ b/packages/contract-event-stream/package.json
@@ -7,6 +7,11 @@
     "openzeppelin-solidity": "^2.1.1",
     "rxjs": "^6.3.3"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/drizzle-utils.git",
+    "directory": "packages/contract-event-stream"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/contract-state-stream/package.json
+++ b/packages/contract-state-stream/package.json
@@ -7,6 +7,11 @@
     "@truffle/decoder": "^3.0.12",
     "rxjs": "^6.3.3"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/drizzle-utils.git",
+    "directory": "packages/contract-state-stream"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,11 @@
     "@drizzle-utils/get-web3": "^0.2.2-alpha.0",
     "@drizzle-utils/new-block-stream": "^0.3.0-alpha.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/drizzle-utils.git",
+    "directory": "packages/core"
+  },
   "gitHead": "78353207c5f530445bc5966013595809bc14506c",
   "publishConfig": {
     "access": "public"

--- a/packages/current-account-stream/package.json
+++ b/packages/current-account-stream/package.json
@@ -6,6 +6,11 @@
   "dependencies": {
     "rxjs": "^6.3.3"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/drizzle-utils.git",
+    "directory": "packages/current-account-stream"
+  },
   "gitHead": "78353207c5f530445bc5966013595809bc14506c",
   "publishConfig": {
     "access": "public"

--- a/packages/get-accounts/package.json
+++ b/packages/get-accounts/package.json
@@ -3,6 +3,11 @@
   "version": "0.2.0",
   "main": "index.js",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/drizzle-utils.git",
+    "directory": "packages/get-accounts"
+  },
   "gitHead": "78353207c5f530445bc5966013595809bc14506c",
   "publishConfig": {
     "access": "public"

--- a/packages/get-balance-stream/package.json
+++ b/packages/get-balance-stream/package.json
@@ -6,6 +6,11 @@
   "dependencies": {
     "rxjs": "^6.3.3"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/drizzle-utils.git",
+    "directory": "packages/get-balance-stream"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/get-contract-instance/package.json
+++ b/packages/get-contract-instance/package.json
@@ -3,6 +3,11 @@
   "version": "0.2.0",
   "main": "index.js",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/drizzle-utils.git",
+    "directory": "packages/get-contract-instance"
+  },
   "gitHead": "78353207c5f530445bc5966013595809bc14506c",
   "publishConfig": {
     "access": "public"

--- a/packages/get-web3/package.json
+++ b/packages/get-web3/package.json
@@ -6,6 +6,11 @@
   "dependencies": {
     "web3": "^1.2.1"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/drizzle-utils.git",
+    "directory": "packages/get-web3"
+  },
   "gitHead": "78353207c5f530445bc5966013595809bc14506c",
   "publishConfig": {
     "access": "public"

--- a/packages/new-block-stream/package.json
+++ b/packages/new-block-stream/package.json
@@ -6,6 +6,11 @@
   "dependencies": {
     "rxjs": "^6.3.3"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/drizzle-utils.git",
+    "directory": "packages/new-block-stream"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/test-chain/package.json
+++ b/packages/test-chain/package.json
@@ -3,6 +3,11 @@
   "version": "0.2.0",
   "main": "index.js",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/drizzle-utils.git",
+    "directory": "packages/test-chain"
+  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
Hi there!
This change adds the repository property to your package.json file(s). Having this available provides a number of benefits to security tooling. For example, it allows for greater trust by checking for signed commits, contributors to a release and validating history with the project. It also allows for comparison between the source code and the published artifact in order to detect attacks on authors during the publication process.
We validate that we're making a PR against the correct repository by comparing the metadata for the published artifact on [npmjs.com](www.npmjs.com) against the metadata in the package.json file in the repository.
This change is provided by a team at Microsoft -- we're happy to answer any questions you may have. (Members of this team include [@s-tuli](https://github.com/s-tuli), [@iarna](https://github.com/iarna), [@v-rr](https://github.com/v-rr), [@v-jiepeng](https://github.com/v-jiepeng), [@v-zhzhou](https://github.com/v-zhzhou) and [@v-gjy](https://github.com/v-gjy)). If you would prefer that we not make these sorts of PRs to projects you maintain, please just say. If you'd like to learn more about what we're doing here, we've prepared a document talking about both this project and some of our other activities around supply chain security here: [microsoft/Secure-Supply-Chain](https://github.com/microsoft/Secure-Supply-Chain)
This PR provides repository metadata for the following packages:
* @drizzle-utils/contract-call-stream
* @drizzle-utils/contract-event-stream
* @drizzle-utils/contract-state-stream
* @drizzle-utils/core
* @drizzle-utils/current-account-stream
* @drizzle-utils/get-accounts
* @drizzle-utils/get-balance-stream
* @drizzle-utils/get-contract-instance
* @drizzle-utils/get-web3
* @drizzle-utils/new-block-stream
* @drizzle-utils/test-chain